### PR TITLE
feat: return token on signup and enable auto-login after registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,3 +88,14 @@ All notable changes to this project will be documented in this file.
 - Refactored frontend form structure for stability and clarity
 - Creation of a Field component to manage form inputs
 - Updated inputs in editUser to use defaultValue
+
+## [v0.3.2] – 2025-06-20
+
+### ✨ Added
+
+- Auto-login after successful signup via direct token return from backend
+
+### 🔧 Changed
+
+- Modified backend `/signup` response to include JWT token
+- Updated frontend flow to store token and redirect without requiring manual login

--- a/backend/server/controllers/userCtrl.js
+++ b/backend/server/controllers/userCtrl.js
@@ -27,7 +27,16 @@ exports.signup = (req, res) => {
       })
       user
         .save()
-        .then(() => res.status(201).json({ message: "User created !" }))
+        .then((savedUser) => {
+          const token = jwt.sign(
+            { userId: savedUser._id },
+            process.env.SECRET_KEY,
+            {
+              expiresIn: "24h",
+            }
+          )
+          return res.status(201).json({ token })
+        })
         .catch((err) => {
           const { status, errors } = handleMongooseError(err)
           return res.status(status).json({ errors })

--- a/frontend/src/features/authentication/AuthenticationAction.jsx
+++ b/frontend/src/features/authentication/AuthenticationAction.jsx
@@ -50,7 +50,6 @@ export const createUser = createAsyncThunk(
         }
       })
       .then((data) => {
-        console.log(data.token)
         window.sessionStorage.setItem("keys", data.token)
         dispatch(setAccess())
         window.location.href = "/profile"


### PR DESCRIPTION
###  Changes
- Modified backend `/signup` to return a token upon successful user creation
- Frontend now logs in the user automatically after signup
- Prepares base for smoother first-time experience and UX continuity

###  Tested
- Manual signup confirms token reception and sessionStorage update
- Auto-redirect to `/profile` successful